### PR TITLE
Added ability to pass token into getStories options

### DIFF
--- a/index.js
+++ b/index.js
@@ -38,11 +38,13 @@ class Storyblok {
     if (!options) { options = {}; }
     let version = options.version;
     if (!version) { version = 'published'; }
+    let token = options.token;
+    if (!token) { token = this.getToken(version); }
 
     let requestUrl = url.parse(`${this.endpoint}v1/cdn/stories`, true);
 
     requestUrl.query.version = version;
-    requestUrl.query.token = this.getToken(version);
+    requestUrl.query.token = token;
 
     return apiRequest(requestUrl);
   }


### PR DESCRIPTION
Added this so that story blok can be instantiated at the top of the
page once, but per request we can pass in a unique token. Allows for
better support in multi-tenant applications.